### PR TITLE
fix: Clippy warnings

### DIFF
--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -36,4 +36,3 @@ impl GameAction {
         map
     }
 }
-

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -44,7 +44,7 @@ pub enum WhichMenu {
 }
 
 impl WhichMenu {
-    pub fn to_view(&self, assets: &MenuAssets, menus: &Assets<Menu>) -> Menu {
+    pub fn to_view(self, assets: &MenuAssets, menus: &Assets<Menu>) -> Menu {
         menus
             .get(match self {
                 Self::Main => &assets.main,
@@ -116,8 +116,8 @@ fn menu_transition(transition: In<Option<StateTransitionEvent<WhichMenu>>>, worl
         return;
     }
 
-    let _ = world.run_system_once(cleanup_menu);
-    let _ = world.run_system_once(setup_menu);
+    world.run_system_once(cleanup_menu);
+    world.run_system_once(setup_menu);
 }
 
 fn move_focus(actions: Res<ActionState<GameAction>>) {

--- a/src/menu/utils.rs
+++ b/src/menu/utils.rs
@@ -3,7 +3,7 @@ use bevy_quill::{Callback, Cx};
 
 pub fn open_link(cx: &mut Cx, link: impl AsRef<str> + Send + Sync + 'static) -> Callback {
     cx.create_callback(move || {
-        if let Err(error) = webbrowser::open(&link.as_ref()) {
+        if let Err(error) = webbrowser::open(link.as_ref()) {
             warn!("Failed to open link {error:?}");
         }
     })


### PR DESCRIPTION
- I was using `let _ = ...` in a few places, which is a clippy warning.
- I had an unnecessary `&` before `AsRef::as_ref``